### PR TITLE
Fixed bug with date formatting

### DIFF
--- a/src/MS/Email/Parser/Message.php
+++ b/src/MS/Email/Parser/Message.php
@@ -71,7 +71,7 @@ class Message
 
     public function getDateAsDateTime()
     {
-        return \DateTime::createFromFormat('D, j M Y H:i:s O *', $this->date);
+        return \DateTime::createFromFormat('D, j M Y H:i:s O+', $this->date);
     }
 
     /**

--- a/src/MS/Email/Parser/Message.php
+++ b/src/MS/Email/Parser/Message.php
@@ -71,7 +71,7 @@ class Message
 
     public function getDateAsDateTime()
     {
-        return \DateTime::createFromFormat('D, j M Y H:i:s O', $this->date);
+        return \DateTime::createFromFormat('D, j M Y H:i:s O *', $this->date);
     }
 
     /**


### PR DESCRIPTION
Some dates in email header can be formatted as:
Tue, 26 May 2020 15:25:30 +0200 (CEST)
The (CEST) at the end of the date causes an error and will return a result of false unless the + is at the end.